### PR TITLE
ツイート投稿機能

### DIFF
--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -164,9 +164,16 @@
 .tweet-text-box{
   min-height: 12rem; //"min-"を追記。画像が枠内に収まるようにするため
   padding-top: 20px;
-  margin-top: 3rem;
 }
 
 .submit-end-btn{
   margin-bottom: 80px;
+}
+
+.tweet-title-box{
+  margin-bottom: 2rem;
+  padding:0.5rem;
+  width: 100%;
+  border: 1px solid #bbb;
+  border-radius: 3px;
 }

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -23,6 +23,6 @@ class TweetsController < ApplicationController
 
   private
   def tweet_params
-    params.require(:tweet).permit(:content).merge(user_id: current_user.id)
+    params.require(:tweet).permit(:title, :content).merge(user_id: current_user.id)
   end
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -2,4 +2,5 @@ class Tweet < ApplicationRecord
   has_rich_text :content
   belongs_to :user
   has_one_attached :image
+  validates :title, presence: true
 end

--- a/app/views/tweets/_form.html.erb
+++ b/app/views/tweets/_form.html.erb
@@ -12,11 +12,12 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :ツイートする, class: "form-label"%>
-    <%= f.rich_text_area :content, autofocus: true, class: "input-box tweet-text-box", placeholder: "今何してる？" %>
+    <%= f.label :自由にツイートしてみよう！, class: "form-label"%>
+    <%= f.text_field :title, class: "tweet-title-box", placeholder: "タイトル" %>
+    <%= f.rich_text_area :content, class: "input-box tweet-text-box", placeholder: "今何してる？" %>
   </div>
 
-  <div class="actions_btn">
-    <%= f.submit %>
+  <div class="actions_btn submit-end-btn">
+    <%= f.submit :ツイートする%>
   </div>
 <% end %>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -1,10 +1,6 @@
 <%###.*_*.### ツイート記事新規投稿ページ ###.*_*.###%>
 
-
-<%#`````` ヘッダー ```````#%>
-<header></header>
-<%#```` 後ほど置き換え ````#%>
-
+<%= render 'shared/header' %>
 
 <div class="post post-tweet">
   <%# BootStrap仮置き %>
@@ -13,4 +9,4 @@
   <%= render 'form', tweet: @tweet %>
 </div>
 
-<footer></footer>
+<%= render 'shared/footer' %>

--- a/db/migrate/20210609081352_create_tweets.rb
+++ b/db/migrate/20210609081352_create_tweets.rb
@@ -1,6 +1,7 @@
 class CreateTweets < ActiveRecord::Migration[6.0]
   def change
     create_table :tweets do |t|
+      t.string     :title, null: false
       t.references :user,  foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2021_06_09_110557) do
 
   create_table "action_text_rich_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -44,15 +43,13 @@ ActiveRecord::Schema.define(version: 2021_06_09_110557) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-ActiveRecord::Schema.define(version: 2021_05_25_092618) do
-
   create_table "charas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "text", null: false
-    t.integer "area", null: false
-    t.integer "gender", null: false
+    t.integer "area_id", null: false
+    t.integer "gender_id", null: false
     t.integer "age", null: false
-    t.integer "job_style", null: false
-    t.integer "exercise_style", null: false
+    t.integer "job_style_id", null: false
+    t.integer "exercise_style_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -60,9 +57,9 @@ ActiveRecord::Schema.define(version: 2021_05_25_092618) do
   end
 
   create_table "people", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "height"
-    t.integer "weight"
-    t.integer "goal"
+    t.integer "height", null: false
+    t.integer "weight", null: false
+    t.integer "goal", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -70,6 +67,7 @@ ActiveRecord::Schema.define(version: 2021_05_25_092618) do
   end
 
   create_table "tweets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title", null: false
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -77,6 +75,7 @@ ActiveRecord::Schema.define(version: 2021_05_25_092618) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -91,4 +90,5 @@ ActiveRecord::Schema.define(version: 2021_05_25_092618) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "charas", "users"
   add_foreign_key "people", "users"
+  add_foreign_key "tweets", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+
 ActiveRecord::Schema.define(version: 2021_06_09_110557) do
 
   create_table "action_text_rich_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -43,13 +44,15 @@ ActiveRecord::Schema.define(version: 2021_06_09_110557) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+ActiveRecord::Schema.define(version: 2021_05_25_092618) do
+
   create_table "charas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "text", null: false
-    t.integer "area_id", null: false
-    t.integer "gender_id", null: false
+    t.integer "area", null: false
+    t.integer "gender", null: false
     t.integer "age", null: false
-    t.integer "job_style_id", null: false
-    t.integer "exercise_style_id", null: false
+    t.integer "job_style", null: false
+    t.integer "exercise_style", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -57,9 +60,9 @@ ActiveRecord::Schema.define(version: 2021_06_09_110557) do
   end
 
   create_table "people", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "height", null: false
-    t.integer "weight", null: false
-    t.integer "goal", null: false
+    t.integer "height"
+    t.integer "weight"
+    t.integer "goal"
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -74,7 +77,6 @@ ActiveRecord::Schema.define(version: 2021_06_09_110557) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -89,5 +91,4 @@ ActiveRecord::Schema.define(version: 2021_06_09_110557) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "charas", "users"
   add_foreign_key "people", "users"
-  add_foreign_key "tweets", "users"
 end


### PR DESCRIPTION
# What
ツイート投稿機能の実装
# Why
ツイートを投稿できるようにするため
# 補足
- 前回、辰巳さんにレビュー頂いたプルリクエストのURLになります。
https://github.com/shogosuzuki712/tripleth/pull/33
-- 保存ボタンの名前変更`済み`
-- ヘッダーフッター呼び出し`済み`
-- ツイートのtitleを追加`済み`
- gyazoになります
https://gyazo.com/5e5d458d58c3ba3f2ced5ffac262fa94
-- title追加後も保存OKです
- コミット名`schema.rbコンフリクト修正`に関しては議事録に記載しておりましたが、`titleカラム`の追加に伴い`rails db:migrate`を実行したことで最新状態に書き換えられました。結果、議事録の問題は解決したと思います。